### PR TITLE
Remove "status:" from routes

### DIFF
--- a/components/car-simulator/manifests/car-simulator-route.yaml
+++ b/components/car-simulator/manifests/car-simulator-route.yaml
@@ -14,5 +14,3 @@ spec:
     name: car-simulator
     weight: 100
   wildcardPolicy: None
-status:
-  ingress: []

--- a/components/dashboard/manifests/dashboard-route.yaml
+++ b/components/dashboard/manifests/dashboard-route.yaml
@@ -13,5 +13,3 @@ spec:
     name: dashboard
     weight: 100
   wildcardPolicy: None
-status:
-  ingress: []

--- a/helm/bobbycar-core-apps/templates/car-simulator-route.yaml
+++ b/helm/bobbycar-core-apps/templates/car-simulator-route.yaml
@@ -14,5 +14,3 @@ spec:
     name: {{ .Values.carSimulator.name }}
     weight: 100
   wildcardPolicy: None
-status:
-  ingress: []

--- a/helm/bobbycar-core-apps/templates/dashboard-route.yaml
+++ b/helm/bobbycar-core-apps/templates/dashboard-route.yaml
@@ -14,5 +14,3 @@ spec:
     name: dashboard
     weight: 100
   wildcardPolicy: None
-status:
-  ingress: []


### PR DESCRIPTION
Whenever we deploy things via gitops this causes argo do complain about
the object not being in sync.
The ingress status will be "Accepted" plus same additional metadata as
soon as the route is accepted, so no point in adding this
status.ingress: [] state in the definition.
