### PR TITLE
refactor: Use String type instead of UUID type

### DIFF
--- a/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/cars/Car.java
+++ b/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/cars/Car.java
@@ -1,6 +1,5 @@
 package com.redhat.bobbycar.carsim.cars;
 
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -14,7 +13,7 @@ public class Car implements OTAListener {
 	private final String model;
 	private final String manufacturer;
 	private final Engine engine;
-	private final UUID driverId;
+	private final String driverId;
 	private String vin;
 	private static final Logger LOGGER = LoggerFactory.getLogger(Car.class);
 
@@ -51,7 +50,7 @@ public class Car implements OTAListener {
 		return manufacturer;
 	}
 
-	public UUID getDriverId() {
+	public String getDriverId() {
 		return driverId;
 	}
 
@@ -78,7 +77,7 @@ public class Car implements OTAListener {
 	public static final class Builder {
 		private String model;
 		private String manufacturer;
-		private UUID driverId;
+		private String driverId;
 		private Engine engine;
 		private String vin;
 
@@ -95,7 +94,7 @@ public class Car implements OTAListener {
 			return this;
 		}
 
-		public Builder withDriverId(UUID driverId) {
+		public Builder withDriverId(String driverId) {
 			this.driverId = driverId;
 			return this;
 		}

--- a/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/cars/EngineMetrics.java
+++ b/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/cars/EngineMetrics.java
@@ -1,7 +1,6 @@
 package com.redhat.bobbycar.carsim.cars;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Metadata;
@@ -26,7 +25,7 @@ public class EngineMetrics {
 	private static final Logger LOGGER = LoggerFactory.getLogger(EngineMetrics.class);
 	private Optional<EngineData> engineData;
 
-	public EngineMetrics(MetricRegistry registry, UUID driverId, String routeName) {
+	public EngineMetrics(MetricRegistry registry, String driverId, String routeName) {
 		super();
 		String routeNameOrUnknown = (routeName != null && routeName.trim().length() > 0) ? routeName : "unknown";
 		LOGGER.debug("Register metrics with tags driver='{}' and route='{}'", driverId, routeName);
@@ -53,11 +52,11 @@ public class EngineMetrics {
 				"", registry, driverId, routeNameOrUnknown);
 	}
 
-	private void register(String name, Gauge<?> gauge, String unit, MetricRegistry registry, UUID driverId,
+	private void register(String name, Gauge<?> gauge, String unit, MetricRegistry registry, String driverId,
 			String routeName) {
 		Metadata metadata = Metadata.builder().withName(name).withType(MetricType.GAUGE).withUnit(unit).build();
 		registry.register(metadata, gauge, 
-				new Tag(TAG_DRIVER, driverId.toString()), 
+				new Tag(TAG_DRIVER, driverId),
 				new Tag(TAG_ROUTE, routeName));
 	}
 

--- a/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/data/CarDao.java
+++ b/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/data/CarDao.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -13,17 +12,17 @@ import com.redhat.bobbycar.carsim.drivers.Driver;
 
 @ApplicationScoped
 public class CarDao {
-    private final Map<UUID, Car> cars = new HashMap<>();
+    private final Map<String, Car> cars = new HashMap<>();
 
     public Collection<Car> getAllCars() {
         return cars.values();
     }
 
-    public Car create(UUID id, Car car) {
+    public Car create(String id, Car car) {
         return cars.put(id, car);
     }
 
-    public Optional<Car> getById(UUID id) {
+    public Optional<Car> getById(String id) {
         return Optional.ofNullable(cars.get(id));
     }
 }

--- a/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/data/DriverDao.java
+++ b/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/data/DriverDao.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import javax.enterprise.context.ApplicationScoped;
 
@@ -12,17 +11,17 @@ import com.redhat.bobbycar.carsim.drivers.Driver;
 
 @ApplicationScoped
 public class DriverDao {
-	private final Map<UUID, Driver> drivers = new HashMap<>();
+	private final Map<String, Driver> drivers = new HashMap<>();
 	
 	public Collection<Driver> getAllDrivers() {
 		return drivers.values();
 	}
 	
-	public Driver create(UUID id, Driver driver) {
+	public Driver create(String id, Driver driver) {
 		return drivers.put(id, driver);
 	}
 	
-	public Optional<Driver> getById(UUID id) {
+	public Optional<Driver> getById(String id) {
 		return Optional.ofNullable(drivers.get(id));
 	}
 }

--- a/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/drivers/Driver.java
+++ b/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/drivers/Driver.java
@@ -4,7 +4,6 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -24,7 +23,7 @@ public class Driver implements Runnable{
 	private Optional<RoutePoint> lastPoint = Optional.empty();
 	private final DrivingStrategy drivingStrategy;
 	private final Optional<DriverMetrics> metrics;
-	private final UUID id;
+	private final String id;
 	private final String routeName;
 	private final boolean repeat;
 	private final long startDelay;
@@ -87,7 +86,7 @@ public class Driver implements Runnable{
 		}
 	}
 
-	public UUID getId() {
+	public String getId() {
 		return id;
 	}
 
@@ -118,7 +117,7 @@ public class Driver implements Runnable{
 		private DriverMetrics metrics;
 		private long startDelay = 0;
 		private boolean repeat;
-		private UUID id;
+		private String id;
 
 		private Builder() {
 		}
@@ -148,7 +147,7 @@ public class Driver implements Runnable{
 			return this;
 		}
 		
-		public Builder withId(UUID id) {
+		public Builder withId(String id) {
 			this.id = id;
 			return this;
 		}

--- a/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/rest/CarResource.java
+++ b/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/rest/CarResource.java
@@ -31,18 +31,18 @@ public class CarResource {
     }
 
     @GET
-    @Path("/{uuid}")
+    @Path("/{id}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getByUUID(@PathParam("uuid") UUID uuid) {
-        Optional<Car> car = carDao.getById(uuid);
+    public Response getByID(@PathParam("id") String id) {
+        Optional<Car> car = carDao.getById(id);
         return Response.ok(car).build();
     }
 
     @POST
-    @Path("/{uuid}/vin/{vin}")
+    @Path("/{id}/vin/{vin}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response assignVin(@PathParam("uuid") UUID uuid, @PathParam("vin") String vin) {
-        Optional<Car> car = carDao.getById(uuid);
+    public Response assignVin(@PathParam("id") String id, @PathParam("vin") String vin) {
+        Optional<Car> car = carDao.getById(id);
         car.ifPresent(c -> {
             c.assignVin(vin);
         });

--- a/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/rest/CarSimulationResource.java
+++ b/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/rest/CarSimulationResource.java
@@ -39,7 +39,7 @@ public class CarSimulationResource {
 	@Path("/{id}/route")
 	@Produces(MediaType.SERVER_SENT_EVENTS)
 	@SseElementType(MediaType.APPLICATION_JSON)
-	public Multi<CarEventDto> getRoute(@PathParam("id") UUID id) {
+	public Multi<CarEventDto> getRoute(@PathParam("id") String id) {
 		return Multi.createFrom().emitter(em -> 
 			driverDao.getById(id).ifPresent(d -> d.registerCarEventListener(evt -> em.emit(new CarEventDto(evt))))
 		);

--- a/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/rest/model/CarSimulationDto.java
+++ b/components/car-simulator/src/main/java/com/redhat/bobbycar/carsim/rest/model/CarSimulationDto.java
@@ -1,11 +1,10 @@
 package com.redhat.bobbycar.carsim.rest.model;
 
 import java.time.ZonedDateTime;
-import java.util.UUID;
 
 public class CarSimulationDto {
 
-	private UUID id;
+	private String id;
 	private ZonedDateTime start;
 	private ZonedDateTime end;
 	private CarDto car;
@@ -15,7 +14,7 @@ public class CarSimulationDto {
 		
 	}
 
-	public CarSimulationDto(UUID id, ZonedDateTime start, ZonedDateTime end, CarDto car, RouteDto route) {
+	public CarSimulationDto(String id, ZonedDateTime start, ZonedDateTime end, CarDto car, RouteDto route) {
 		super();
 		this.id = id;
 		this.start = start;
@@ -24,11 +23,11 @@ public class CarSimulationDto {
 		this.route = route;
 	}
 	
-	public UUID getId() {
+	public String getId() {
 		return id;
 	}
 
-	public void setId(UUID id) {
+	public void setId(String id) {
 		this.id = id;
 	}
 

--- a/components/car-simulator/src/test/java/com/redhat/bobbycar/carsim/DriverTest.java
+++ b/components/car-simulator/src/test/java/com/redhat/bobbycar/carsim/DriverTest.java
@@ -38,7 +38,7 @@ class DriverTest {
 		TimedEngine engine = TimedEngine.builder().withSpeedVariationInKmH(5).withStartingPoint(route.getPoints().findFirst().orElse(null))
 				.withConfig(new JsonEngineConfiguration()).build();
 		Car car = Car.builder().withModel("M3 Coupe").withManufacturer("BMW")
-				.withEngine(engine).withDriverId(UUID.randomUUID()).build();
+				.withEngine(engine).withDriverId(UUID.randomUUID().toString()).build();
 		DrivingStrategy strategy = TimedDrivingStrategy.builder().withCar(car).build();
 		Driver driver = Driver.builder().withRoute(route).withDrivingStrategy(strategy).build();
 		driver.registerCarEventListener(evt -> {


### PR DESCRIPTION
Creating ID using UUIDv4 is fine, but when using Drogue IoT, those ID won't be UUID, but some string ID.

In most cases this is used with .toString() anyway.